### PR TITLE
Fix db provision script to use proper values instead of hard coded ones

### DIFF
--- a/scripts/database-provision.sh
+++ b/scripts/database-provision.sh
@@ -1,13 +1,42 @@
 #!/usr/bin/env bash
 
+set -euo pipefail
+
+# Get the directory of the current script.
+SCRIPT_DIR_PATH="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
+
+# Construct the path to the `.env.local` file by navigating up one directory.
+ENV_LOCAL_FILE_PATH="${SCRIPT_DIR_PATH}/../.env.local"
+
+# Check if the `.env.local` file exists.
+if [ ! -f "${ENV_LOCAL_FILE_PATH}" ]; then
+    echo "Error: .env.local file does not exist at ${ENV_LOCAL_FILE_PATH} path."
+    exit 1
+fi
+
+# Source the `.env.local` file in a way that supports non-exported variables.
+while IFS='=' read -r key value; do
+  # Skip lines that are empty or start with a hash (comments).
+  [[ -z $key || $key =~ ^# ]] && continue
+
+  # Remove potential leading "export " in each line for file consistency.
+  key=${key#export }
+
+  # Use eval to correctly handle values with spaces.
+  eval export "$key='$value'"
+
+# Do it through all lines in `.env.local` file.
+done < "${ENV_LOCAL_FILE_PATH}"
+
+# Import fixtures into db
 surreal import \
-    --conn http://localhost:8000 \
-    --user root --pass root \
-    --ns test --db test \
+    --conn "$SURREALDB_URL" \
+    --user "$SURREALDB_USER" --pass "$SURREALDB_PASS" \
+    --ns "$SURREALDB_NS" --db "$SURREALDB_DB" \
     fixtures/nonce-schema.surql && \
 
 surreal import \
-    --conn http://localhost:8000 \
-    --user root --pass root \
-    --ns test --db test \
+    --conn "$SURREALDB_URL" \
+    --user "$SURREALDB_USER" --pass "$SURREALDB_PASS" \
+    --ns "$SURREALDB_NS" --db "$SURREALDB_DB" \
     fixtures/tokens.surql

--- a/scripts/database-provision.sh
+++ b/scripts/database-provision.sh
@@ -2,31 +2,34 @@
 
 set -euo pipefail
 
-# Get the directory of the current script.
-SCRIPT_DIR_PATH="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
+# Check if we're not running in CI where we need to source environment variables.
+if [ "$CI" = "false" ]; then
+  # Get the directory of the current script.
+  SCRIPT_DIR_PATH="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
 
-# Construct the path to the `.env.local` file by navigating up one directory.
-ENV_LOCAL_FILE_PATH="${SCRIPT_DIR_PATH}/../.env.local"
+  # Construct the path to the `.env.local` file by navigating up one directory.
+  ENV_LOCAL_FILE_PATH="${SCRIPT_DIR_PATH}/../.env.local"
 
-# Check if the `.env.local` file exists.
-if [ ! -f "${ENV_LOCAL_FILE_PATH}" ]; then
-    echo "Error: .env.local file does not exist at ${ENV_LOCAL_FILE_PATH} path."
-    exit 1
+  # Check if the `.env.local` file exists.
+  if [ ! -f "${ENV_LOCAL_FILE_PATH}" ]; then
+      echo "Error: .env.local file does not exist at ${ENV_LOCAL_FILE_PATH} path."
+      exit 1
+  fi
+
+  # Source the `.env.local` file in a way that supports non-exported variables.
+  while IFS='=' read -r key value; do
+    # Skip lines that are empty or start with a hash (comments).
+    [[ -z $key || $key =~ ^# ]] && continue
+
+    # Remove potential leading "export " in each line for file consistency.
+    key=${key#export }
+
+    # Use eval to correctly handle values with spaces.
+    eval export "$key='$value'"
+
+  # Do it through all lines in `.env.local` file.
+  done < "${ENV_LOCAL_FILE_PATH}"
 fi
-
-# Source the `.env.local` file in a way that supports non-exported variables.
-while IFS='=' read -r key value; do
-  # Skip lines that are empty or start with a hash (comments).
-  [[ -z $key || $key =~ ^# ]] && continue
-
-  # Remove potential leading "export " in each line for file consistency.
-  key=${key#export }
-
-  # Use eval to correctly handle values with spaces.
-  eval export "$key='$value'"
-
-# Do it through all lines in `.env.local` file.
-done < "${ENV_LOCAL_FILE_PATH}"
 
 # Import fixtures into db
 surreal import \


### PR DESCRIPTION
This PR is updating `database-provision.sh` script to:
- [x] Secure script with `-euo pipefail`,
- [x] In non CI environment, get `.env.local` file, source all variables and use them in `surreal import` command.