### PR TITLE
DB provision script fix - set default value for CI env variable to `false`

### DIFF
--- a/scripts/database-provision.sh
+++ b/scripts/database-provision.sh
@@ -2,8 +2,9 @@
 
 set -euo pipefail
 
-# Check if the CI environment variable exists and is set to `false`, which determines
-# that we run script locally and we need to source environment variables.
+# Check if the CI environment variable exists - if not, set default value to `false`,
+# if yes, check if it is set to `false`, which determines that we run script locally
+# and we need to source environment variables.
 if [ "${CI:-false}" = "false" ]; then
   # Get the directory of the current script.
   SCRIPT_DIR_PATH="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"

--- a/scripts/database-provision.sh
+++ b/scripts/database-provision.sh
@@ -2,8 +2,9 @@
 
 set -euo pipefail
 
-# Check if we're not running in CI where we need to source environment variables.
-if [ "$CI" = "false" ]; then
+# Check if the CI environment variable exists and is set to `false`, which determines
+# that we run script locally and we need to source environment variables.
+if [ "${CI:-false}" = "false" ]; then
   # Get the directory of the current script.
   SCRIPT_DIR_PATH="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
 


### PR DESCRIPTION
Fix `database-provision.sh` script failure due to lack of `CI` environment variable on local machines by setting up default value for `CI` variable to `false` (which CI environment will override with `true`).