### PR TITLE
- fixed token delete

### DIFF
--- a/src/components/groups/group.tsx
+++ b/src/components/groups/group.tsx
@@ -49,7 +49,7 @@ function extractData(
 
   return extractedArray.map((entry: any, index: number) => (
     <Token
-      key={`token_${index}`}
+      key={`${entry.balanceId} - ${index}`}
       icon={`/images/svg/tokens/${entry.symbol.toLowerCase()}.svg`}
       name={entry.name}
       symbol={entry.symbol}


### PR DESCRIPTION
- When token from top/middle of the list got deleted some values got mixed together (name, icon, quantity remained from the deleted one, whereas other came in place correctly). That must've been cause by the Token component key. This PR fixes it.